### PR TITLE
Start use method.full_name for throttle empty scope instead of uuid

### DIFF
--- a/tests/controllers/__init__.py
+++ b/tests/controllers/__init__.py
@@ -7,6 +7,6 @@ from .controller_with_path_parameters import ControllerWithPathParameters
 from .controller_with_query_parameters import ControllerWithQueryParameters
 from .controller_with_response_headers import ControllerWithResponseHeaders
 from .controller_with_serializer import ControllerWithSerializer
-from .controller_with_throttling import ControllerWithThrottlingOnMethod
+from .controller_with_throttling import ControllerWithThrottling
 from .no_authentication_controller import NoAuthenticationController
 from .simple_controller import SimpleController

--- a/tests/controllers/__init__.py
+++ b/tests/controllers/__init__.py
@@ -7,7 +7,6 @@ from .controller_with_path_parameters import ControllerWithPathParameters
 from .controller_with_query_parameters import ControllerWithQueryParameters
 from .controller_with_response_headers import ControllerWithResponseHeaders
 from .controller_with_serializer import ControllerWithSerializer
-from .controller_with_throttling import ControllerWithThrottlingOnController
 from .controller_with_throttling import ControllerWithThrottlingOnMethod
 from .no_authentication_controller import NoAuthenticationController
 from .simple_controller import SimpleController

--- a/tests/controllers/controller_with_throttling.py
+++ b/tests/controllers/controller_with_throttling.py
@@ -1,24 +1,4 @@
-import winter.http
 import winter
-
-
-@winter.http.throttling('6/s', scope='ControllerWithThrottlingOnController')
-@winter.no_authentication
-@winter.route_get('with-throttling-on-controller/')
-class ControllerWithThrottlingOnController:
-
-    @winter.route_get()
-    def simple_method(self):
-        return 1
-
-    @winter.route_get('same/')
-    def same_simple_method(self):
-        return 1
-
-    @winter.http.throttling(None)
-    @winter.route_post()
-    def method_without_throttling(self):
-        return None
 
 
 @winter.route_get('with-throttling-on-method/')

--- a/tests/controllers/controller_with_throttling.py
+++ b/tests/controllers/controller_with_throttling.py
@@ -1,7 +1,7 @@
 import winter
 
 
-@winter.route_get('with-throttling-on-method/')
+@winter.route_get('with-throttling/')
 @winter.no_authentication
 class ControllerWithThrottlingOnMethod:
 

--- a/tests/controllers/controller_with_throttling.py
+++ b/tests/controllers/controller_with_throttling.py
@@ -3,7 +3,7 @@ import winter
 
 @winter.route_get('with-throttling/')
 @winter.no_authentication
-class ControllerWithThrottlingOnMethod:
+class ControllerWithThrottling:
 
     @winter.route_get()
     @winter.http.throttling('5/s')

--- a/tests/test_throttling.py
+++ b/tests/test_throttling.py
@@ -7,7 +7,7 @@ from .entities import AuthorizedUser
 
 
 @pytest.mark.parametrize('need_auth', (True, False))
-def test_throttling_on_method(need_auth):
+def test_throttling(need_auth):
     client = APIClient()
     if need_auth:
         user = AuthorizedUser()

--- a/tests/test_throttling.py
+++ b/tests/test_throttling.py
@@ -1,55 +1,9 @@
-import sys
-
-import datetime
 from http import HTTPStatus
 
 import pytest
 from rest_framework.test import APIClient
 
 from .entities import AuthorizedUser
-
-
-@pytest.mark.parametrize('need_auth', (True, False))
-def test_throttling(need_auth):
-    client = APIClient()
-
-    if need_auth:
-        user = AuthorizedUser()
-        client.force_authenticate(user)
-
-    for i in range(1, 5):
-        response = client.get('/with-throttling-on-controller/')
-        response_of_same = client.get('/with-throttling-on-controller/same/')
-
-        if i > 6 // 2:
-            assert response.status_code == response_of_same.status_code == HTTPStatus.TOO_MANY_REQUESTS, i
-        else:
-            assert response.status_code == response_of_same.status_code == HTTPStatus.OK, i
-
-
-def test_throttling_discards_old_requests():
-    if sys.version_info > (3, 8):
-        return
-
-    from freezegun import freeze_time
-
-    client = APIClient()
-    user = AuthorizedUser()
-    client.force_authenticate(user)
-
-    with freeze_time(datetime.datetime(2000, 1, 1, second=0, microsecond=0)):
-        for _ in range(3):
-            client.get('/with-throttling-on-controller/')
-
-    with freeze_time(datetime.datetime(2000, 1, 1, second=0, microsecond=600000)):
-        for _ in range(2):
-            client.get('/with-throttling-on-controller/')
-
-    # Act
-    with freeze_time(datetime.datetime(2000, 1, 1, second=1, microsecond=0)):
-        response = client.get('/with-throttling-on-controller/')
-
-    assert response.status_code == HTTPStatus.OK
 
 
 @pytest.mark.parametrize('need_auth', (True, False))
@@ -68,16 +22,12 @@ def test_throttling_on_method(need_auth):
             assert response.status_code == response_of_same.status_code == HTTPStatus.OK, i
 
 
-@pytest.mark.parametrize(('url', 'method'), (
-    ('/with-throttling-on-method/without-throttling/', 'get'),
-    ('/with-throttling-on-controller/', 'post'),
-))
-def test_throttling_without_throttling(url, method):
+def test_throttling_without_throttling():
     client = APIClient()
     user = AuthorizedUser()
     client.force_authenticate(user)
 
     for i in range(1, 10):
-        client_method = getattr(client, method)
-        response = client_method(url)
+        client_method = getattr(client, 'get')
+        response = client_method('/with-throttling-on-method/without-throttling/')
         assert response.status_code == HTTPStatus.OK, i

--- a/tests/test_throttling.py
+++ b/tests/test_throttling.py
@@ -14,8 +14,8 @@ def test_throttling_on_method(need_auth):
         client.force_authenticate(user)
 
     for i in range(1, 10):
-        response = client.get('/with-throttling-on-method/')
-        response_of_same = client.get('/with-throttling-on-method/same/')
+        response = client.get('/with-throttling/')
+        response_of_same = client.get('/with-throttling/same/')
         if i > 5:
             assert response.status_code == response_of_same.status_code == HTTPStatus.TOO_MANY_REQUESTS, i
         else:
@@ -29,5 +29,5 @@ def test_throttling_without_throttling():
 
     for i in range(1, 10):
         client_method = getattr(client, 'get')
-        response = client_method('/with-throttling-on-method/without-throttling/')
+        response = client_method('/with-throttling/without-throttling/')
         assert response.status_code == HTTPStatus.OK, i

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -12,7 +12,6 @@ urlpatterns = [
     *winter.django.create_django_urls(controllers.ControllerWithQueryParameters),
     *winter.django.create_django_urls(controllers.ControllerWithResponseHeaders),
     *winter.django.create_django_urls(controllers.ControllerWithSerializer),
-    *winter.django.create_django_urls(controllers.ControllerWithThrottlingOnController),
     *winter.django.create_django_urls(controllers.ControllerWithThrottlingOnMethod),
     *winter.django.create_django_urls(controllers.ControllerWithLimits),
     *winter.django.create_django_urls(controllers.ControllerWithRequestData),

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
     *winter.django.create_django_urls(controllers.ControllerWithQueryParameters),
     *winter.django.create_django_urls(controllers.ControllerWithResponseHeaders),
     *winter.django.create_django_urls(controllers.ControllerWithSerializer),
-    *winter.django.create_django_urls(controllers.ControllerWithThrottlingOnMethod),
+    *winter.django.create_django_urls(controllers.ControllerWithThrottling),
     *winter.django.create_django_urls(controllers.ControllerWithLimits),
     *winter.django.create_django_urls(controllers.ControllerWithRequestData),
 ]

--- a/winter/django.py
+++ b/winter/django.py
@@ -52,7 +52,7 @@ def _create_django_view(controller_class, component, routes: List[Route]):
     class WinterView(rest_framework.views.APIView):
         authentication_classes = (SessionAuthentication,)
         permission_classes = (IsAuthenticated,) if is_authentication_needed(component) else ()
-        throttle_classes = create_throttle_classes(component, routes)
+        throttle_classes = create_throttle_classes(routes)
 
     # It's useful for New Relic APM
     WinterView.__module__ = controller_class.__module__

--- a/winter/http/throttling.py
+++ b/winter/http/throttling.py
@@ -96,7 +96,7 @@ def create_throttle_classes(
 
         if getattr(throttling_annotation, 'rate', None) is not None:
             num_requests, duration = _parse_rate(throttling_annotation.rate)
-            throttling_scope = throttling_annotation.scope or route.method.func.__qualname__
+            throttling_scope = throttling_annotation.scope or route.method.full_name
             throttling_ = Throttling(num_requests, duration, throttling_scope)
             throttling_by_http_method_[route.http_method.lower()] = throttling_
 

--- a/winter/http/throttling.py
+++ b/winter/http/throttling.py
@@ -5,7 +5,6 @@ import dataclasses
 from django.core.cache import cache as default_cache
 from rest_framework.throttling import BaseThrottle
 
-from ..core import Component
 from ..core import annotate_method
 
 if typing.TYPE_CHECKING:

--- a/winter/http/throttling.py
+++ b/winter/http/throttling.py
@@ -81,18 +81,11 @@ def _parse_rate(rate: str) -> typing.Tuple[int, int]:
     return num_requests, duration
 
 
-def create_throttle_classes(
-        component: Component,
-        routes: typing.List['Route'],
-) -> typing.Tuple[typing.Type[BaseRateThrottle], ...]:
-    base_throttling_annotation = component.annotations.get_one_or_none(ThrottlingAnnotation)
+def create_throttle_classes(routes: typing.List['Route']) -> typing.Tuple[typing.Type[BaseRateThrottle], ...]:
     throttling_by_http_method_: typing.Dict[str, Throttling] = {}
 
     for route in routes:
-
-        throttling_annotation = (
-            route.method.annotations.get_one_or_none(ThrottlingAnnotation) or base_throttling_annotation
-        )
+        throttling_annotation = route.method.annotations.get_one_or_none(ThrottlingAnnotation)
 
         if getattr(throttling_annotation, 'rate', None) is not None:
             num_requests, duration = _parse_rate(throttling_annotation.rate)


### PR DESCRIPTION
**Start use ` method.full_name` for throttle empty scope instead of UUID**

For apps running in several workers throttling works incorrectly:  
if the scope was not specified UUID was used. This led to using the same endpoints more than forbidden times - because of using different UUIDs in each worker.

Now if the scope is not set, the full name of the method will be used.  
It gets the ` full_name` of the method.

With this using @winter.http.throttling is not applicable - It's not obvious how throttling should work in cases when the scope is set or when it's empty  
So now it's possible to add @winter.http.throttling only on the methods.