### PR TITLE
Simplify MethodExceptionsHandler

### DIFF
--- a/winter/django.py
+++ b/winter/django.py
@@ -84,11 +84,12 @@ def _call_controller_method(controller, route: Route, request: Request):
     try:
         arguments = arguments_resolver.resolve_arguments(method, request, response_headers)
         result = method(controller, **arguments)
-        response = convert_result_to_http_response(request, result, method)
     except method_exceptions_handler.exception_classes as exception:
         response = method_exceptions_handler.handle(exception, request, response_headers)
         if response is None:
             raise
+    else:
+        response = convert_result_to_http_response(request, result, method)
 
     _fill_response_headers(response, response_headers)
     return response

--- a/winter/schema/generation.py
+++ b/winter/schema/generation.py
@@ -62,10 +62,10 @@ def build_responses_schemas(route: Route):
     response_status = str(get_default_response_status(http_method, route.method))
 
     responses[response_status] = build_response_schema(route.method)
-    method_exceptions_handler = MethodExceptionsManager(route.method)
+    method_exceptions_manager = MethodExceptionsManager(route.method)
 
-    for exception_cls in method_exceptions_handler.declared_exception_classes:
-        handler = method_exceptions_handler.get_handler(exception_cls)
+    for exception_cls in method_exceptions_manager.declared_exception_classes:
+        handler = method_exceptions_manager.get_handler(exception_cls)
         if handler is None:
             handler = exception_handlers_registry.get_handler(exception_cls)
         if handler is None:

--- a/winter/schema/generation.py
+++ b/winter/schema/generation.py
@@ -12,7 +12,7 @@ from .. import type_utils
 from ..core import ComponentMethod
 from ..core import ComponentMethodArgument
 from ..drf import get_output_serializer
-from ..exceptions.handlers import MethodExceptionsHandler
+from ..exceptions.handlers import MethodExceptionsManager
 from ..exceptions.handlers import exception_handlers_registry
 from ..http.default_response_status import get_default_response_status
 from ..routing import Route
@@ -62,7 +62,7 @@ def build_responses_schemas(route: Route):
     response_status = str(get_default_response_status(http_method, route.method))
 
     responses[response_status] = build_response_schema(route.method)
-    method_exceptions_handler = MethodExceptionsHandler(route.method)
+    method_exceptions_handler = MethodExceptionsManager(route.method)
 
     for exception_cls in method_exceptions_handler.declared_exception_classes:
         handler = method_exceptions_handler.get_handler(exception_cls)


### PR DESCRIPTION
MethodExceptionsHandler is no longer a handler (renamed to a Manager). It just provides you with the proper handler for a given exception.
I managed to reduce the number of usages of convert_result_to_http_response from 2 to 1.
Now it should be easier to go further.