### PR TITLE
Release 32.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [32.1.0] - 2026-04-28
+- Added Django 5.2 support (widened constraint to >=4.2,<6)
+- Fixed duplicate inspector registration in register_route_parameters_inspector
+
 ## [32.0.0] - 2026-04-27
 - Bumped minimum pydantic version to 2.13
 - Fixed Parameter import to use openapi-pydantic v3.0 consistently

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "winter"
-version = "32.0.0"
+version = "32.1.0"
 homepage = "https://github.com/WinterFramework/winter"
 description = "Web Framework with focus on python typing, dataclasses and modular design"
 authors = ["Alexander Egorov <mofr@zond.org>"]


### PR DESCRIPTION
## Summary

- Bump version to 32.1.0
- Add CHANGELOG entry for 32.1.0:
  - Added Django 5.2 support (widened constraint to >=4.2,<6)
  - Fixed duplicate inspector registration in register_route_parameters_inspector